### PR TITLE
remove cobertura plugin as incompatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,12 +325,6 @@
 
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
                     <version>3.0.2</version>
                 </plugin>


### PR DESCRIPTION
with recent SonarQube instances.

see
  - http://docs.sonarqube.org/display/PLUG/Plugin+Version+Matrix
  - https://github.com/SonarQubeCommunity/sonar-cobertura/issues/4